### PR TITLE
Rename Docker Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/github/license/bartongroup/slivka-bio-docker)](LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/bartongroup/slivka-bio-docker)](https://github.com/bartongroup/slivka-bio-docker/issues)
 
-This repository contains the Docker configuration for setting up `slivka-bio`. You can find a pre-built image of [slivka-bio on Docker Hub](https://hub.docker.com/r/stuartmac/slivka-bio-docker).
+This repository contains the Docker configuration for setting up `slivka-bio`. You can find a pre-built image of [slivka-bio on Docker Hub](https://hub.docker.com/r/stuartmac/slivka-bio).
 
 ## Overview
 

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   slivka-bio:
     image: stuartmac/slivka-bio:latest

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   slivka-bio:
-    image: stuartmac/slivka-bio-docker
+    image: stuartmac/slivka-bio
     volumes:
       - media:/app/media
     ports:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   slivka-bio:
-    image: stuartmac/slivka-bio
+    image: stuartmac/slivka-bio:latest
     volumes:
       - media:/app/media
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   slivka-bio:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   slivka-bio:
     image: stuartmac/slivka-bio:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   slivka-bio:
-    image: stuartmac/slivka-bio-docker
+    image: stuartmac/slivka-bio
     volumes:
       - media:/app/media
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   slivka-bio:
-    image: stuartmac/slivka-bio
+    image: stuartmac/slivka-bio:latest
     volumes:
       - media:/app/media
     ports:


### PR DESCRIPTION
### Rename Docker Repo

I renamed the Docker Hub image from `slivka-bio-docker` to `slivka-bio` for consistency and easier recognition. This required re-tagging and pushing the image to Docker Hub, followed by updating all references.

Here's the new link: https://hub.docker.com/r/stuartmac/slivka-bio

**Changes:**

1. **Image Renaming and Push**:
   
   ```bash
   # Tag the new image
   docker tag stuartmac/slivka-bio-docker:latest stuartmac/slivka-bio:latest
   
   # Push the re-tagged image to Docker Hub
   docker push stuartmac/slivka-bio:latest
   
2. **Docker Hub Documentation**:
   
   - Copied repository description, categories, and overview to the new Docker Hub page for slivka-bio.
   
3. **Changes**:

   - **README**: Updated Docker Hub link
   - **Compose Files:** Updated image name in docker-compose.yml and .demo compose files. I also removed the deprecated schema version specification for better compatibility with newer Docker Compose standards.

**Verification**: Successfully tested with updated docker-compose files to ensure correct image build and run.