### PR TITLE
support for Apple silicon and additional instructions for launching the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To get started with `slivka-bio-docker`:
 
   If you are working on Apple Silicon (or other arm64 architectures)
   ```bash
-  docker-compose up -d -f docker-compose.arm64.yaml
+  docker-compose -f docker-compose.arm64.yaml up -d
   ```
 
 This will build the `slivka-bio` image and start all the services as defined in the `docker-compose.yml`.
@@ -50,7 +50,10 @@ This will build the `slivka-bio` image and start all the services as defined in 
 This command will start both slivka-bio and a JupyterLab server:
 
    ```bash
-   docker-compose up -d -f docker-compose.demo.${$(uname -m):s/arm64/arm64.}yaml
+   docker-compose -f docker-compose.demo.yml up -d
+
+   # or for Apple Sillicon
+   docker-compose -f docker-compose.arm64.demo.yml up -d
    ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This command will start both slivka-bio and a JupyterLab server:
 
    ```bash
    docker-compose up -d -f docker-compose.demo.${$(uname -m):s/arm64/arm64.}yaml
+   ```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@ To get started with `slivka-bio-docker`:
    docker-compose up -d
    ```
 
+  If you are working on Apple Silicon (or other arm64 architectures)
+  ```bash
+  docker-compose up -d -f docker-compose.arm64.yaml
+  ```
+
 This will build the `slivka-bio` image and start all the services as defined in the `docker-compose.yml`.
+
+### Jupyter Notebook Demo
+
+This command will start both slivka-bio and a JupyterLab server:
+
+   ```bash
+   docker-compose up -d -f docker-compose.demo.${$(uname -m):s/arm64/arm64.}yaml
 
 ## Configuration
 

--- a/docker-compose.arm64.demo.yml
+++ b/docker-compose.arm64.demo.yml
@@ -3,7 +3,7 @@ name: slivka-bio-demo
 services:
   slivka-bio:
     image: stuartmac/slivka-bio:latest
-    platform: linux/amd64
+    platform: linux/amd64  # silences warning on arm64 at startup
     volumes:
       - media:/app/media
     ports:

--- a/docker-compose.arm64.demo.yml
+++ b/docker-compose.arm64.demo.yml
@@ -1,0 +1,35 @@
+services:
+  slivka-bio:
+    image: stuartmac/slivka-bio:latest
+    platform: linux/amd64
+    volumes:
+      - media:/app/media
+    ports:
+      - "8080:8000"
+    depends_on:
+      - mongo
+    environment:
+      - MONGODB_URI=mongodb://mongo:27017/slivka
+
+  mongo:
+    image: arm64v8/mongo:latest
+    platform: linux/arm64/v8
+    volumes:
+      - mongo_data:/data/db
+    ports:
+      - "27017:27017"
+
+  jupyter:
+    image: jupyter/base-notebook:latest
+    platform: linux/amd64
+    volumes:
+      - ./demo:/home/jovyan
+    ports:
+      - "8888:8888"
+    environment:
+      - JUPYTER_ENABLE_LAB=yes
+    command: start-notebook.sh --NotebookApp.token=''
+
+volumes:
+  media:
+  mongo_data:

--- a/docker-compose.arm64.demo.yml
+++ b/docker-compose.arm64.demo.yml
@@ -1,3 +1,5 @@
+name: slivka-bio-demo
+
 services:
   slivka-bio:
     image: stuartmac/slivka-bio:latest

--- a/docker-compose.arm64.demo.yml
+++ b/docker-compose.arm64.demo.yml
@@ -23,7 +23,7 @@ services:
 
   jupyter:
     image: jupyter/base-notebook:latest
-    platform: linux/amd64
+    platform: linux/arm64
     volumes:
       - ./demo:/home/jovyan
     ports:

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,7 +1,7 @@
 services:
   slivka-bio:
     image: stuartmac/slivka-bio:latest
-    platform: linux/amd64
+    platform: linux/amd64  # silences warning on arm64 at startup
     volumes:
       - media:/app/media
     ports:

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,0 +1,24 @@
+services:
+  slivka-bio:
+    image: stuartmac/slivka-bio:latest
+    platform: linux/amd64
+    volumes:
+      - media:/app/media
+    ports:
+      - "8080:8000"
+    depends_on:
+      - mongo
+    environment:
+      - MONGODB_URI=mongodb://mongo:27017/slivka
+
+  mongo:
+    image: arm64v8/mongo:latest
+    platform: linux/arm64/v8
+    volumes:
+      - mongo_data:/data/db
+    ports:
+      - "27017:27017"
+
+volumes:
+  media:
+  mongo_data:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,3 +1,5 @@
+name: slivka-bio-demo
+
 services:
   slivka-bio:
     image: stuartmac/slivka-bio:latest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+name: slivka-bio-dev
+
 services:
   slivka-bio:
     build: .


### PR DESCRIPTION
this needs testing on a vanilla apple silicon system running a recent version of Docker, since I used [lima](https://gist.github.com/akrylysov/7c1ea3bac409da2758e525f2f82e6373). @jamesabbott may also have opinions on running mixed-arch containers.

